### PR TITLE
fix old version problem

### DIFF
--- a/raspberry_pi/mqtt-install.sh
+++ b/raspberry_pi/mqtt-install.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+sudo apt-add-repository ppa:mosquitto-dev/mosquitto-ppa -y
 sudo apt update -y && sudo apt install mosquitto mosquitto-clients -y
 
 echo "Please enter your username and press Enter"


### PR DESCRIPTION
Versions of ubuntu older that 22.04 may have old version of mosquitto broker. This line fix problem